### PR TITLE
Fix typo in title

### DIFF
--- a/directory-structure.md
+++ b/directory-structure.md
@@ -1,6 +1,6 @@
 ---
 extends: docs
-title: "Dirctory structure"
+title: "Directory structure"
 group: "Basics"
 subgroup: "General"
 prev: deployment


### PR DESCRIPTION
This PR fixes a typo in the title for `Directory structure`.